### PR TITLE
[ENGT-4446] Force Table.refresh() in IcebergFilesCommitter.initializeState

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -150,6 +150,14 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     // Open the table loader and load the table.
     this.tableLoader.open();
     this.table = tableLoader.loadTable();
+    // Force a fresh metadata fetch. Grepr's GreprCachingCatalog returns a cached BaseTable
+    // whose underlying TableOperations may carry shouldRefresh=false from a prior background
+    // refresh, missing commits made on a different TaskManager since that refresh. The
+    // SinkUtil.getMaxCommittedCheckpointId call below relies on seeing those commits to take
+    // the SKIP branch when restoring from a savepoint that was committed elsewhere — without
+    // this refresh, it walks stale snapshot history and tries to read a Flink-temp manifest
+    // the previous job has already committed and deleted.
+    this.table.refresh();
     this.committerMetrics = new IcebergFilesCommitterMetrics(super.metrics, table.name());
 
     maxContinuousEmptyCommits =


### PR DESCRIPTION
## Summary

Adds `this.table.refresh()` immediately after `tableLoader.loadTable()` in `IcebergFilesCommitter.initializeState`. Forces a `doRefresh()` (Glue/Hive `GetTable` + metadata reload) before `SinkUtil.getMaxCommittedCheckpointId` walks the snapshot history during state restore.

## Why

When Grepr's `GreprCachingCatalog` returns a cached `BaseTable`, its `TableOperations` may carry `shouldRefresh=false` from a prior background-refresher tick. If a savepoint+restart sequence completes within the staleness window between background refreshes, the new `IcebergFilesCommitter` task can land on a TaskManager whose cached metadata predates the OLD job's just-completed commit. `getMaxCommittedCheckpointId` then walks stale snapshot history, returns a value below the savepoint checkpoint id, and `commitUpToCheckpoint` attempts to read a Flink-temp manifest the OLD job has already committed and `deleteCommittedManifests`-deleted. Result: `org.apache.iceberg.exceptions.NotFoundException` on every restart attempt until the BG refresher catches up.

`Table.refresh()` unconditionally calls `doRefresh()`, bypassing the `shouldRefresh` short-circuit. The `getMaxCommittedCheckpointId` call that follows then walks fresh snapshot history, finds the OLD job's commit, and the SKIP branch fires correctly.

Investigation, evidence, and the regression test live in [ENGT-4446](https://www.notion.so/359e242667728185ba46dc9cab496f13). The corresponding regression test lands in the grepr-server PR.

## Test plan

- Verified with `IcebergFilesCommitterStaleCacheRestoreTest` in grepr-server that drives a real `IcebergFilesCommitter` through the bug-reproduction sequence (cache pre-warm → OLD operator snapshot → external manifest delete → external commit → NEW operator restore). Pre-fix: throws `NotFoundException`. Post-fix: `initializeState` succeeds, SKIP branch fires.

## Cost

One extra Glue/Hive `GetTable` plus metadata.json read per task initialization. Task initialization is rare (once per task lifetime), and these calls are inexpensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)